### PR TITLE
Update API endpoint and add timeout to CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30  # Add a timeout of 30 minutes
     
     steps:
       - uses: actions/checkout@v3

--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func handleTestCommand() error {
 
 	resp, err := client.R().
 		SetHeader("User-Agent", "InventoryPrinter/1.0").
-		Get("http://192.168.1.104:5000/apptest")
+		Get("https://inventory.sensefinity.com/apptest")
 
 	if err != nil {
 		log.Printf("Error making request: %v", err)


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and the `main.go` file to improve reliability and security. The most important changes are:

Workflow improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R14): Added a timeout of 30 minutes to the jobs matrix to prevent long-running jobs from hanging indefinitely.

Security and reliability enhancements:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L45-R45): Updated the URL in the `handleTestCommand` function to use a secure HTTPS connection and the production domain `inventory.sensefinity.com` instead of a local IP address.