### PR TITLE
Rename module to match repository path and update Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yourusername/InventoryTPrinting
+module github.com/SensefinityCloud/InventoryTPrinting
 
 go 1.23
 


### PR DESCRIPTION
This pull request includes a change to the `go.mod` file to update the module path and Go version.

* Updated module path from `InventoryTPrinter` to `github.com/yourusername/InventoryTPrinting` to reflect the correct repository URL.
* Changed the Go version from `1.23.5` to `1.23` to align with the standard versioning format.