### PR TITLE
Fix build command in release workflow to use current directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           GOOS: ${{ matrix.os == 'windows-latest' && 'windows' || 'linux' }}
           GOARCH: amd64
         run: |
-          go build -o dist/inventory-printer${{ matrix.os == 'windows-latest' && '.exe' || '' }} main.go
+          go build -o dist/inventory-printer${{ matrix.os == 'windows-latest' && '.exe' || '' }} .
         
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change modifies the `go build` command to use the current directory instead of specifying the `main.go` file directly.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L29-R29): Updated the `go build` command to use the current directory instead of `main.go`.