### PR TITLE
Refactor Windows protocol handling by moving implementation to a separate file

### DIFF
--- a/register.go
+++ b/register.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-
-	"golang.org/x/sys/windows"
 )
 
 // Public API
@@ -55,61 +53,6 @@ func NeedsPathUpdate() bool {
 	default:
 		return false
 	}
-}
-
-// Windows Implementation
-// ----------------------------------------
-
-func windowsProtocolExists() bool {
-	cmd := exec.Command("powershell", "-Command", `
-		Test-Path -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer"
-	`)
-	output, err := cmd.Output()
-	return err == nil && strings.TrimSpace(string(output)) == "True"
-}
-
-func windowsNeedsPathUpdate() bool {
-	cmd := exec.Command("powershell", "-Command", `
-		(Get-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer\shell\open\command").'(Default)'
-	`)
-	output, err := cmd.Output()
-	if err != nil {
-		return true
-	}
-
-	currentExePath, err := os.Executable()
-	if err != nil {
-		return true
-	}
-
-	registryPath := strings.TrimSpace(string(output))
-	registryPath = strings.Trim(registryPath, `"`)
-	registryPath = strings.Split(registryPath, `" "`)[0]
-
-	return !strings.EqualFold(registryPath, currentExePath)
-}
-
-func registerWindowsProtocol(exePath string) {
-	if !isAdmin() {
-		elevatePrivileges()
-		return
-	}
-
-	psCmd := fmt.Sprintf(`
-		New-Item -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer" -Force
-		Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer" -Name "(Default)" -Value "URL:Inventory Printer Protocol"
-		Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer" -Name "URL Protocol" -Value ""
-		New-Item -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer\shell\open\command" -Force
-		Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer\shell\open\command" -Name "(Default)" -Value '"%s" "%%1"'
-	`, strings.ReplaceAll(exePath, `\`, `\\`))
-
-	cmd := exec.Command("powershell", "-Command", psCmd)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		fmt.Printf("Failed to register Windows protocol: %v\nOutput: %s\n", err, string(out))
-		return
-	}
-
-	fmt.Println("Windows protocol handler registered successfully")
 }
 
 // Linux Implementation
@@ -172,31 +115,4 @@ MimeType=x-scheme-handler/inventoryt-printer;
 	}
 
 	fmt.Println("Linux protocol handler registered successfully")
-}
-
-// Utility Functions
-// ----------------------------------------
-
-func isAdmin() bool {
-	_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
-	return err == nil
-}
-
-func elevatePrivileges() {
-	verb := "runas"
-	exe, _ := os.Executable()
-	cwd, _ := os.Getwd()
-
-	verbPtr, _ := windows.UTF16PtrFromString(verb)
-	exePtr, _ := windows.UTF16PtrFromString(exe)
-	cwdPtr, _ := windows.UTF16PtrFromString(cwd)
-	argPtr, _ := windows.UTF16PtrFromString("")
-
-	var showCmd int32 = 1 //SW_NORMAL
-
-	err := windows.ShellExecute(0, verbPtr, exePtr, argPtr, cwdPtr, showCmd)
-	if err != nil {
-		fmt.Printf("Failed to elevate privileges: %v\n", err)
-	}
-	os.Exit(0)
 }

--- a/register_windows.go
+++ b/register_windows.go
@@ -1,0 +1,89 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func windowsProtocolExists() bool {
+	cmd := exec.Command("powershell", "-Command", `
+		Test-Path -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer"
+	`)
+	output, err := cmd.Output()
+	return err == nil && strings.TrimSpace(string(output)) == "True"
+}
+
+func windowsNeedsPathUpdate() bool {
+	cmd := exec.Command("powershell", "-Command", `
+		(Get-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer\shell\open\command").'(Default)'
+	`)
+	output, err := cmd.Output()
+	if err != nil {
+		return true
+	}
+
+	currentExePath, err := os.Executable()
+	if err != nil {
+		return true
+	}
+
+	registryPath := strings.TrimSpace(string(output))
+	registryPath = strings.Trim(registryPath, `"`)
+	registryPath = strings.Split(registryPath, `" "`)[0]
+
+	return !strings.EqualFold(registryPath, currentExePath)
+}
+
+func registerWindowsProtocol(exePath string) {
+	if !isAdmin() {
+		elevatePrivileges()
+		return
+	}
+
+	psCmd := fmt.Sprintf(`
+		New-Item -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer" -Force
+		Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer" -Name "(Default)" -Value "URL:Inventory Printer Protocol"
+		Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer" -Name "URL Protocol" -Value ""
+		New-Item -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer\shell\open\command" -Force
+		Set-ItemProperty -Path "HKLM:\SOFTWARE\Classes\inventoryt-printer\shell\open\command" -Name "(Default)" -Value '"%s" "%%1"'
+	`, strings.ReplaceAll(exePath, `\`, `\\`))
+
+	cmd := exec.Command("powershell", "-Command", psCmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Printf("Failed to register Windows protocol: %v\nOutput: %s\n", err, string(out))
+		return
+	}
+
+	fmt.Println("Windows protocol handler registered successfully")
+}
+
+func isAdmin() bool {
+	_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
+	return err == nil
+}
+
+func elevatePrivileges() {
+	verb := "runas"
+	exe, _ := os.Executable()
+	cwd, _ := os.Getwd()
+
+	verbPtr, _ := windows.UTF16PtrFromString(verb)
+	exePtr, _ := windows.UTF16PtrFromString(exe)
+	cwdPtr, _ := windows.UTF16PtrFromString(cwd)
+	argPtr, _ := windows.UTF16PtrFromString("")
+
+	var showCmd int32 = 1 //SW_NORMAL
+
+	err := windows.ShellExecute(0, verbPtr, exePtr, argPtr, cwdPtr, showCmd)
+	if err != nil {
+		fmt.Printf("Failed to elevate privileges: %v\n", err)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
This pull request primarily involves refactoring the Windows-specific code from `register.go` into a new file, `register_windows.go`. This change improves code organization by separating platform-specific implementations.

Refactoring and code organization:

* Moved Windows-specific functions (`windowsProtocolExists`, `windowsNeedsPathUpdate`, `registerWindowsProtocol`, `isAdmin`, `elevatePrivileges`) from `register.go` to a new file `register_windows.go`. [[1]](diffhunk://#diff-35226dfb96a9957e34eafa29be3901d8f226a5138894b6e593ecdcdb35840984L60-L114) [[2]](diffhunk://#diff-35226dfb96a9957e34eafa29be3901d8f226a5138894b6e593ecdcdb35840984L176-L202) [[3]](diffhunk://#diff-83d94f67d11a3c2ebef30e88c7e86d9261570c045310258d245210c27cfe268eR1-R89)
* Removed the import of `golang.org/x/sys/windows` from `register.go` since it is now only used in `register_windows.go`.