### PR TITLE
Update Go version to 1.21 and adjust module dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'  # Updated from 1.20 to 1.21
           
       - name: Build Application
         env:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/SensefinityCloud/InventoryTPrinting
 
-go 1.23
+go 1.21
 
 require (
-	github.com/go-resty/resty/v2 v2.16.4 // indirect
-	golang.org/x/net v0.33.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
+	github.com/go-resty/resty/v2 v2.16.4
+	golang.org/x/sys v0.29.0
 )
+
+require golang.org/x/net v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
+golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=


### PR DESCRIPTION
This pull request includes updates to the Go version used in the project and some changes to the `go.mod` file to manage dependencies more effectively.

Go version update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R22): Updated the Go version from 1.20 to 1.21 in the GitHub Actions workflow.

Dependency management:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R10): Updated the Go version from 1.23 to 1.21 and reorganized the dependencies to ensure correct indirect references.