### PR TITLE
Add stub for Windows protocol handling on non-Windows platforms

### DIFF
--- a/register_windows_stub.go
+++ b/register_windows_stub.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+func windowsProtocolExists() bool {
+	return false
+}
+
+func windowsNeedsPathUpdate() bool {
+	return false
+}
+
+func registerWindowsProtocol(exePath string) {
+	// Do nothing on non-Windows platforms
+}


### PR DESCRIPTION
This pull request includes platform-specific stubs for Windows-related functions in the `register_windows_stub.go` file. These changes ensure that the code behaves correctly on non-Windows platforms by providing no-op implementations of Windows-specific functions.

Platform-specific stubs:

* [`register_windows_stub.go`](diffhunk://#diff-2c12acad8c364242b20d07de76290401d478a23aab6cde24d1c061065c12c735R1-R16): Added stubs for `windowsProtocolExists`, `windowsNeedsPathUpdate`, and `registerWindowsProtocol` functions to return default values or do nothing on non-Windows platforms.