### PR TITLE
Update GitHub Actions to use upload-artifact@v4 for artifact management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           rm dist/inventory-printer  # Remove raw binary
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-build
           path: |


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration for the release process. The most important change is the upgrade of the `upload-artifact` action from version 3 to version 4.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L56-R56): Updated the `upload-artifact` action to use version 4.