### PR TITLE
Update GitHub Actions to use download-artifact@v4 for improved artifact management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration in the `.github/workflows/release.yml` file. The change updates the version of the `actions/download-artifact` action from version 3 to version 4.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L68-R68): Updated `actions/download-artifact` action from version 3 to version 4.